### PR TITLE
Automatic cluster network configuration

### DIFF
--- a/profiles/SCI-amd64.files/files/ganeti/hooks/add-node-post.d/deploy-ganeti-networks
+++ b/profiles/SCI-amd64.files/files/ganeti/hooks/add-node-post.d/deploy-ganeti-networks
@@ -1,5 +1,0 @@
-#!/bin/sh
-test -n "$GANETI_NODE_NAME" || exit 0
-if [ "$GANETI_MASTER" = "`hostname`" ]; then
-  scp /etc/ganeti/networks $GANETI_NODE_NAME:/etc/ganeti/networks
-fi

--- a/profiles/SCI-amd64.files/files/ganeti/hooks/node-add-post.d/deploy-ganeti-networks
+++ b/profiles/SCI-amd64.files/files/ganeti/hooks/node-add-post.d/deploy-ganeti-networks
@@ -1,0 +1,10 @@
+#!/bin/sh
+test -n "$GANETI_NODE_NAME" || exit 0
+if [ "$GANETI_MASTER" = "`hostname`" ]; then
+  # Add node to known_hosts
+  touch /root/.ssh/known_hosts
+  ssh-keyscan -t rsa,dsa $GANETI_NODE_NAME 2>&1 | sort -u - /root/.ssh/known_hosts > /root/.ssh/tmp_hosts
+  cat /root/.ssh/tmp_hosts > /root/.ssh/known_hosts
+  # deploy files
+  scp /etc/ganeti/networks $GANETI_NODE_NAME:/etc/ganeti/networks
+fi

--- a/profiles/SCI-amd64.files/files/ganeti/instance-debootstrap/hooks/interfaces
+++ b/profiles/SCI-amd64.files/files/ganeti/instance-debootstrap/hooks/interfaces
@@ -81,16 +81,21 @@ EOF
      echo Configuring static IP on NIC $i
      # /etc/ganeti/networks has format "NETWORK NETMASK BROADCAST GATEWAY"
      NETWORKNUM=`eval $IP2NET "\\$NIC_${i}_IP"`
+     IP=`eval echo "\\$NIC_${i}_IP"`
      
      if [ -z "$NETWORKNUM" ]; then
-       echo Unable to get network number for NIC $i
-       exit 1
+       echo Unable to guess the network for NIC $i from /etc/ganeti/networks
+       echo using default mask /24
+       NETMASK="255.255.255.0"
+       eval NIC_${i}_NETWORK=`ipcalc -n $IP $NETMASK|awk -F"[: /]+" '/^Network:/{print $2; exit 0}'`
+       eval NIC_${i}_NETMASK=`ipcalc -n $IP $NETMASK|awk -F"[: /]+" '/^Netmask:/{print $2; exit 0}'`
+       eval NIC_${i}_BROADCAST=`ipcalc -n $IP $NETMASK|awk -F"[: /]+" '/^Broadcast:/{print $2; exit 0}'`
+     else
+       eval NIC_${i}_NETWORK=`grep "$NETWORKNUM" /etc/ganeti/networks|awk '{print $1; exit 0}'`
+       eval NIC_${i}_NETMASK=`grep "$NETWORKNUM" /etc/ganeti/networks|awk '{print $2; exit 0}'`
+       eval NIC_${i}_BROADCAST=`grep "$NETWORKNUM" /etc/ganeti/networks|awk '{print $3; exit 0}'`
+       eval NIC_${i}_GATEWAY=`grep "$NETWORKNUM" /etc/ganeti/networks|awk '{print $4; exit 0}'`
      fi
-
-     eval NIC_${i}_NETWORK=`grep "$NETWORKNUM" /etc/ganeti/networks|awk '{print $1; exit 0}'`
-     eval NIC_${i}_NETMASK=`grep "$NETWORKNUM" /etc/ganeti/networks|awk '{print $2; exit 0}'`
-     eval NIC_${i}_BROADCAST=`grep "$NETWORKNUM" /etc/ganeti/networks|awk '{print $3; exit 0}'`
-     eval NIC_${i}_GATEWAY=`grep "$NETWORKNUM" /etc/ganeti/networks|awk '{print $4; exit 0}'`
 
      if [ -z "`eval echo "\\$NIC_${i}_NETWORK"`" ]; then
        echo Unable to get interface settings for network $NETWORKNUM NIC $i
@@ -108,7 +113,8 @@ iface eth$i inet static
 EOF
 
       g=`eval echo "\\$NIC_${i}_GATEWAY"`
-      if [ "$i" = "0" -a -n "$g" ]; then
+      if [ -z "$gateway_set" -a -n "$g" ]; then
+         gateway_set=yes
          cat >> $TARGET/etc/network/interfaces <<EOF
 	gateway `eval echo "\\$NIC_${i}_GATEWAY"`
 EOF

--- a/profiles/SCI-amd64.files/files/sbin/sci-setup
+++ b/profiles/SCI-amd64.files/files/sbin/sci-setup
@@ -1,10 +1,179 @@
 #!/bin/sh
 
+# usage check_ip IP
+# returns NETDEV MASK or exits with error
+check_ip(){
+  /sbin/ifconfig|awk -vip="$1" '
+/^[a-z]/{iface=$1}
+/^[ \t]*inet addr:/{
+  split($2,A,":")
+  addr=A[2]
+  if(addr == ip){
+    for(i=1; i<=NF; i++){
+      if($i ~ /^Mask:/){
+        split($i,M,":")
+        mask=M[2]
+      }
+    }
+    print iface, mask
+    ok = 1
+    exit
+  }
+}
+END{
+  if(ok)exit 0
+  exit 1
+}
+' || (cat <<EOF 1>&2
+ERROR!
+The IP address $1 is NOT UP on the node!
+Check ifconfig, /etc/network/interfaces and /etc/sci/sci.conf
+
+Aborting.
+EOF
+  exit 1)
+}
+
+# usage: check_netdev IFACE PURPOSE
+# exits with error
+check_netdev(){
+  if ! grep -q "^iface $1" /etc/network/interfaces; then
+   cat <<EOF
+ERROR!
+The interface $1 as $2 should be configured and up!
+Check /etc/network/interfaces and /etc/sci/sci.conf
+
+Aborting.
+EOF
+   exit 1
+  fi
+  if ! /sbin/ifconfig|grep -q "^$1 "; then
+   cat <<EOF
+ERROR!
+The interface $1 as $2 seems configured but NOT UP!
+Check ifconfig, /etc/network/interfaces and /etc/sci/sci.conf
+
+Aborting.
+EOF
+   exit 1
+  fi
+}
+
+# check_ip_net IP1 IP2 IP2-MASK
+# return 0 if IP1 in the same network as IP2
+check_ip_net(){
+  m1=`ipcalc -n $1 $3|awk '/^Network:/{print $2}'`
+  m2=`ipcalc -n $2 $3|awk '/^Network:/{print $2}'`
+  test "$m1" = "$m2"
+}
+
+# Create line for /etc/ganeti networks
+# Args: IP NETMASK INTERFACE
+for_networks(){
+  N_NETWORK=`ipcalc -n $1 $2|awk -F"[: /]+" '/^Network:/{print $2; exit 0}'`
+  N_NETMASK=`ipcalc -n $1 $2|awk -F"[: /]+" '/^Netmask:/{print $2; exit 0}'`
+  N_BROADCAST=`ipcalc -n $1 $2|awk -F"[: /]+" '/^Broadcast:/{print $2; exit 0}'`
+  if [ -n "$3" ]; then
+    N_GATEWAY=`ip route |grep "^default via .* dev $3"|cut -d' ' -f 3`
+  else
+    N_GATEWAY=""
+  fi
+  echo $N_NETWORK $N_NETMASK $N_BROADCAST $N_GATEWAY
+}
+
 . /etc/sci/sci.conf
 
 DOMAIN_NAME=`grep '^search' /etc/resolv.conf|head -1|awk '{print $2}'`
-SERVICE_NAME="sci"
-SERVICE_IP=`grep '^nameserver' /etc/resolv.conf|head -1|awk '{print $2}'`
+SCI_NAME="sci"
+SCI_IP=`grep '^nameserver' /etc/resolv.conf|head -1|awk '{print $2}'`
+
+#### Perform some AI
+
+# Check NODE1_IP against ifconfig
+# Get NODE1_NETDEV NODE1_MASK
+# Check NODE1_NETDEV against interfaces
+
+# Check NODE1_LAN_IP against ifconfig
+# Get NODE1_LAN_NETDEV NODE1_LAN_MASK
+# Check NODE1_LAN_NETDEV against interfaces
+
+# Check CLUSTER_IP against NODE1_LAN_x and NODE1_INT_x, try to find CLU_NETDEV, or set to MASTER_NETDEV
+# Check autodetected CLU_NETDEV against MASTER_NETDEV override, abort if not match
+# Set MASTER_NETDEV to match CLU_NETDEV
+# Check LAN_NETDEV against NODE1_LAN_NETDEV and NODE1_NETDEV
+# Set LAN_NETDEV or pass
+
+if [ -z "$CLUSTER_IP" ]; then
+  cat <<EOF
+ERROR!
+The CLUSTER_IP must be set!
+Check /etc/sci/sci.conf
+
+Aborting.
+EOF
+  exit 1
+fi
+
+read NODE1_NETDEV NODE1_MASK <<EOF
+`check_ip $NODE1_IP`
+EOF
+check_netdev $NODE1_NETDEV NODE1_NETDEV
+if check_ip_net $CLUSTER_IP $NODE1_IP $NODE1_MASK; then
+  CLU_NETDEV=$NODE1_NETDEV
+  CLU_NETMASK=$NODE1_MASK
+fi
+
+if [ -n "$NODE1_LAN_IP" ]; then
+  read NODE1_LAN_NETDEV NODE1_LAN_MASK <<EOF
+`check_ip $NODE1_LAN_IP`
+EOF
+  check_netdev $NODE1_LAN_NETDEV NODE1_LAN_NETDEV
+  if check_ip_net $CLUSTER_IP $NODE1_LAN_IP $NODE1_LAN_MASK; then
+    CLU_NETDEV=$NODE1_LAN_NETDEV
+    CLU_NETMASK=$NODE1_LAN_MASK
+  fi
+fi
+
+test -n "$MASTER_NETDEV" && check_netdev $MASTER_NETDEV MASTER_NETDEV
+
+if [ -n "$CLU_NETDEV" ]; then
+  if [ -n "$MASTER_NETDEV" ]; then
+    if [ "$CLU_NETDEV" != "$MASTER_NETDEV" ]; then
+      cat <<EOF
+ERROR!
+The MASTER_NETDEV=$MASTER_NETDEV doesn't match autodetected device $CLU_NETDEV!
+Check /etc/sci/sci.conf
+
+Aborting.
+EOF
+      exit 1
+    fi
+  else
+    MASTER_NETDEV=$CLU_NETDEV
+    MASTER_NETMASK=$CLU_NETMASK
+  fi
+elif [ -z "$MASTER_NETDEV" ]; then
+  cat <<EOF
+ERROR!
+Unable to figure out the MASTER_NETDEV!
+The CLUSTER_IP=$CLUSTER_IP is not a part of configured NODE1 networks.
+And the MASTER_NETDEV override not set.
+Check /etc/sci/sci.conf
+
+Aborting.
+EOF
+  exit 1
+fi
+
+# Here MASTER_NETDEV is always detected
+MASTER_NETMASK=${MASTER_NETMASK:-"255.255.255.0"}
+
+LAN_NETDEV=${LAN_NETDEV:-$NODE1_LAN_NETDEV}
+LAN_NETDEV=${LAN_NETDEV:-$MASTER_NETDEV}
+
+# Here LAN_NETDEV is always detected
+
+#### End AI
 
 case $1 in
 
@@ -14,23 +183,41 @@ cat <<EOF
 Parameters detected:
 Domain name: $DOMAIN_NAME
 
+Master network interface: $MASTER_NETDEV
+
 Cluster name: $CLUSTER_NAME
 Cluster IP: $CLUSTER_IP
 
-Service instance name: $SERVICE_NAME
-Service instance IP: $SERVICE_IP
+Service instance name: $SCI_NAME
+Service instance IP: $SCI_IP
+EOF
+test -n "$SCI_LAN_IP" && echo Service instance LAN IP: $SCI_LAN_IP
+cat <<EOF
 
 Node 1 name: $NODE1_NAME
 Node 1 IP: $NODE1_IP
-
 EOF
+test -n "$NODE1_SAN_IP" && echo Node 1 SAN IP: $NODE1_SAN_IP
+test -n "$NODE1_LAN_IP" && echo Node 1 LAN IP: $NODE1_LAN_IP
+test -n "$LAN_NETDEDV" && echo LAN network interface: $LAN_NETDEV
+echo ""
+
 if [ -n "$NODE2_IP" ]; then
  if [ -n "$NODE1_SAN_IP" -a -z "$NODE2_SAN_IP" ]; then
 cat <<EOF
 ERROR!
 NODE1_SAN_IP is specified but NODE2_SAN_IP is empty.
 Both values must be set or unset.
-The continue will cause error. Aborting.
+This will cause error. Aborting.
+EOF
+  exit 1
+ fi
+ if [ -n "$NODE1_LAN_IP" -a -z "$NODE2_LAN_IP" ]; then
+cat <<EOF
+ERROR!
+NODE1_LAN_IP is specified but NODE2_LAN_IP is empty.
+Both values must be set or unset.
+This will cause error. Aborting.
 EOF
   exit 1
  fi
@@ -38,6 +225,8 @@ EOF
 Node 2 name: $NODE2_NAME
 Node 2 IP: $NODE2_IP
 EOF
+ test -n "$NODE2_SAN_IP" && echo Node 2 SAN IP: $NODE2_SAN_IP
+ test -n "$NODE2_LAN_IP" && echo Node 2 LAN IP: $NODE2_LAN_IP
 else
  cat <<EOF
 WARNING!
@@ -73,25 +262,30 @@ ff02::2 ip6-allrouters
 # cluster
 $CLUSTER_IP	$CLUSTER_NAME.$DOMAIN_NAME $CLUSTER_NAME
 # service machine
-$SERVICE_IP	$SERVICE_NAME.$DOMAIN_NAME $SERVICE_NAME puppet.$DOMAIN_NAME puppet apt.$DOMAIN_NAME apt
+$SCI_IP	$SCI_NAME.$DOMAIN_NAME $SCI_NAME puppet.$DOMAIN_NAME puppet apt.$DOMAIN_NAME apt
 # first nodes
 $NODE1_IP	$NODE1_NAME.$DOMAIN_NAME $NODE1_NAME
 EOF
 
 echo Fulfilling default /etc/ganeti/networks
-# XXX should iterate thru interfaces
-NIC0_NETWORK=`awk '/^[ \t]*network/{print $2; exit 0}' /etc/network/interfaces`
-NIC0_NETMASK=`awk '/^[ \t]*netmask/{print $2; exit 0}' /etc/network/interfaces`
-NIC0_BROADCAST=`awk '/^[ \t]*broadcast/{print $2; exit 0}' /etc/network/interfaces`
-NIC0_GATEWAY=`awk '/^[ \t]*gateway/{print $2; exit 0}' /etc/network/interfaces`
 
-echo $NIC0_NETWORK $NIC0_NETMASK $NIC0_BROADCAST $NIC0_GATEWAY >>/etc/ganeti/networks
+for_networks $NODE1_IP $NODE1_MASK $NODE1_NETDEV >/etc/ganeti/networks
+if [ -n "$NODE1_SAN_IP" ]; then
+  for_networks $NODE1_SAN_IP $NODE1_SAN_MASK >>/etc/ganeti/networks
+fi
+if [ -n "$NODE1_LAN_IP" ]; then
+  for_networks $NODE1_LAN_IP $NODE1_LAN_MASK $NODE1_LAN_NETDEV >>/etc/ganeti/networks
+elif [ -n "$SCI_LAN_IP" ]; then
+  fnx=`for_networks $SCI_LAN_IP ${SCI_LAN_NETMASK:-255.255.255.0}`
+  echo $fnx $SCI_LAN_GATEWAY >>/etc/ganeti/networks 
+fi
 
 echo Initializing cluster
 if [ -n "$NODE1_SAN_IP" ]; then
  SECONDARY_IP="-s $NODE1_SAN_IP"
 fi
-gnt-cluster init --enabled-hypervisors=xen-pvm,xen-hvm --nic-parameters link=$LINK_NETDEV --master-netdev $MASTER_NETDEV $SECONDARY_IP $CLUSTER_NAME
+gnt-cluster init --enabled-hypervisors=xen-pvm,xen-hvm --nic-parameters link=$LAN_NETDEV --master-netdev $MASTER_NETDEV $SECONDARY_IP $CLUSTER_NAME
+# XXX in ganeti 2.6 should be added: --master-netmask $MASTER_NETMASK
 test $? -eq 0 || (echo Something wrong; exit 1)
 
 echo Tuning cluster
@@ -105,9 +299,7 @@ if [ -n "$NODE2_IP" ]; then
  fi
  echo "$NODE2_IP       $NODE2_NAME.$DOMAIN_NAME $NODE2_NAME" >>/etc/hosts
  gnt-node add $SECONDARY_IP $NODE2_NAME
- # XXX check - should be copied by a add-node hook
- #echo Copying /etc/ganeti/networks to $NODE2_NAME:
- #gnt-cluster copyfile /etc/ganeti/networks
+ # NOTE: /etc/ganeti/networks is copied by a node-add-post hook to any new node
 else
  echo "WARNING! Creating SkyCover Infrastructure with on only one node. This is strongly not recommended for production use!"
 fi
@@ -125,18 +317,52 @@ echo If all is ok, proceed with "$0 sci"
 
 sci|service)
 
-if [ -z "$SERVICE_NAME" -o -z "$SERVICE_IP" ]; then
- echo You should carefully fullfill parameters in /etc/sci/sci.conf
- echo Aborted.
+if [ -z "$SCI_NAME" -o -z "$SCI_IP" ]; then
+ cat <<EOF
+SCI_NAME and/or SCI_IP not defined.
+You should carefully fullfill parameters in /etc/sci/sci.conf
+
+Aborting.
+EOF
  exit 1
 fi
 
-echo Creating service machine $SERVICE_NAME
+MASTER_NETDEV=`gnt-cluster info|awk '/- master netdev:/{print $NF; exit 0}'`
+LAN_NETDEV=`gnt-cluster info|awk '/^Default nic parameters:/{s=1}/ *link: /{if(s){print $NF; exit 0}}'`
+if [ "$NODE1_NETDEV" != "$LAN_NETDEV" ]; then
+  LANIF="--net=1:link=$LAN_NETDEV"
+  if [ -n "$SCI_LAN_IP" ]; then
+    if [ -n "$NODE1_LAN_IP" ]; then
+      if ! check_ip_net $SCI_LAN_IP $NODE1_LAN_IP $NODE1_LAN_MASK; then
+        cat <<EOF
+ERROR!
+NODE1_LAN_IP and SCI_LAN_IP are in different networks.
+Check ifconfig, /etc/network/interfaces and /etc/sci/sci.conf
+
+Aborting.
+EOF
+        exit 1
+      fi
+    fi
+    LANIF="$LANIF,ip=$SCI_LAN_IP"
+  fi
+fi
+
+check_netdev $MASTER_NETDEV MASTER_NETDEV
+check_netdev $LAN_NETDEV LAN_NETDEV
+
+cat <<EOF
+Creating service machine $SCI_NAME
+IP: $SCI_IP on $NODE1_NETDEV
+EOF
+test -n "$LANIF" && echo Second network device: $LAN_NETDEV
+test -n "$SCI_LAN_IP" && echo Second network IP: $SCI_LAN_IP
+
 if [ -n "$NODE2_NAME" ]; then
-  gnt-instance add -t drbd -o debootstrap+sci -s 10g -B memory=512m -n $NODE1_NAME:$NODE2_NAME $SERVICE_NAME
+  gnt-instance add -t drbd -o debootstrap+sci -s 10g -B memory=512m --net=0:link=$NODE1_NETDEV $LANIF -n $NODE1_NAME:$NODE2_NAME $SCI_NAME
 else
   echo "WARNING! Creating the service instance without fallback support. This is strongly not recommended for production use!"
-  gnt-instance add -t plain -o debootstrap+sci -s 10g -B memory=512m -n $NODE1_NAME $SERVICE_NAME
+  gnt-instance add -t plain -o debootstrap+sci -s 10g -B memory=512m --net=0:link=$NODE1_NETDEV $LANIF -n $NODE1_NAME $SCI_NAME
 fi
 
 ;;

--- a/profiles/SCI-amd64.files/postinst.sh
+++ b/profiles/SCI-amd64.files/postinst.sh
@@ -416,25 +416,53 @@ cp files/sbin/* $target/usr/local/sbin/
 
 mkdir $target/etc/sci
 cat <<EOF >$target/etc/sci/sci.conf
-# The cluster's name and IP. They MUST be different from node names
-# The cluster's IP will be an interface alias on the current master node
-CLUSTER_NAME=
+# This is the SCI-CD cluster setup parameters
+# Fill the values and execute "sci-setup cluster"
+
+# The cluster's name (without a domain part). It MUST be different from any node's names
+CLUSTER_NAME=gnt
+
+# The cluster's IP. It MUST be different from any node's IP
+# It will be an interface alias on the current master node
+# You should not up this IP address manualy on the node
+# If you have a separate LAN segment then we suggest you to assign this address in the LAN
 CLUSTER_IP=
 
 # The first (master) node data
-# Autofilled on install. On the nodes other than master may be differ, unless synced
 NODE1_NAME=$hostname
 NODE1_IP=$ipaddr
+
+# Optional separate IP for SAN (should be configured and up; ganeti node will be configured with -s option)
 NODE1_SAN_IP=
+# Optional separate IP for LAN (should be configured and up)
+NODE1_LAN_IP=
+
+# Optional additional IP for virtual service machine "sci" in the LAN segment.
+# If NODE1_LAN_IP is set, then you probably wish to set this too.
+# (you should not to pre-configure this IP on the node)
+SCI_LAN_IP=
+# Optional parameters if NODE1_LAN_IP not configured
+# If not set, it will be omited in instance's interface config
+SCI_LAN_NETMASK=
+SCI_LAN_GATEWAY=
 
 # The second node data
+# If you skip NODE2 configuration, then the cluster will be set up in non redundant one-node mode
 NODE2_NAME=
 NODE2_IP=
 NODE2_SAN_IP=
+NODE2_LAN_IP=
 
-#master netdev name
-MASTER_NETDEV=xen-br0
-LINK_NETDEV=xen-br0
+# Network interface for CLUSTER_IP
+# (if set, this interface will be passed to "gnt-cluser init --master-netdev")
+# Autodetect if NODE1_LAN_IP is set and CLUSTER_IP matches LAN network
+MASTER_NETDEV=
+MASTER_NETMASK=
+
+# Network interface to bind to virtual machies by default
+# (if set, this interface will be passed to "gnt-cluster init --nic-parameters link=")
+# Autodetect if NODE1_LAN_IP or MASTER_NETDEV are set
+LAN_NETDEV=
 
 #reserved volumes - what lvm used by nodes system not by cluster(comma separated)
 RESERVED_VOLS="xenvg/system-.*"

--- a/profiles/SCI-amd64.packages
+++ b/profiles/SCI-amd64.packages
@@ -32,3 +32,4 @@ sg3-utils
 lvm2
 lsb-release
 acpi-support-base
+ipcalc


### PR DESCRIPTION
See documetation on the web site
- ipcalc added to packages - for sci-setup

/etc/ganeti/networks improvements
- instance fixed ips may not be gefined in /etc/ganeti/networks
- instance will use the first known gateway
- /etc/ganeti/networks is autofilled with gnt, lan and san networks
- added SCI_LAN_IP SCI_LAN_NETMASK and SCI_LAN_GATEWAY in sci.conf
- Fixed /etc/ganeti/networks deployment hook
