### PR TITLE
Ability to copy-in cd images for newbies

### DIFF
--- a/profiles/SCI-amd64.downloads
+++ b/profiles/SCI-amd64.downloads
@@ -25,7 +25,6 @@ file
 wget
 htop
 links
-mc
 nmap
 zsh
 

--- a/profiles/SCI-amd64.packages
+++ b/profiles/SCI-amd64.packages
@@ -33,3 +33,5 @@ lvm2
 lsb-release
 acpi-support-base
 ipcalc
+mc
+usbmount


### PR DESCRIPTION
usbmount and mc are included to preinstalled packages
mc is removed from "SCI-amd64.downloads" list
