### PR TITLE
Added localization via console-setup

### DIFF
--- a/profiles/SCI-amd64.files/files/default/console-setup
+++ b/profiles/SCI-amd64.files/files/default/console-setup
@@ -1,0 +1,49 @@
+# Change to "yes" and setupcon will explain what is being doing
+VERBOSE_OUTPUT="no"
+
+# Setup these consoles.  Most people do not need to change this.
+ACTIVE_CONSOLES="/dev/tty[1-6]"
+
+# Put here your encoding.  Valid charmaps are: UTF-8 ARMSCII-8 CP1251
+# CP1255 CP1256 GEORGIAN-ACADEMY GEORGIAN-PS IBM1133 ISIRI-3342
+# ISO-8859-1 ISO-8859-2 ISO-8859-3 ISO-8859-4 ISO-8859-5 ISO-8859-6
+# ISO-8859-7 ISO-8859-8 ISO-8859-9 ISO-8859-10 ISO-8859-11 ISO-8859-13
+# ISO-8859-14 ISO-8859-15 ISO-8859-16 KOI8-R KOI8-U TIS-620 VISCII
+CHARMAP="UTF-8"
+
+# The codeset determines which symbols are supported by the font.
+# Valid codesets are: Arabic Armenian CyrAsia CyrKoi CyrSlav Ethiopian
+# Georgian Greek Hebrew Lao Lat15 Lat2 Lat38 Lat7 Thai Uni1 Uni2 Uni3
+# Vietnamese.  Read README.fonts for explanation.
+CODESET="CyrSlav"
+
+# Valid font faces are: VGA (sizes 8, 14 and 16), Terminus (sizes
+# 12x6, 14, 16, 20x10, 24x12, 28x14 and 32x16), TerminusBold (sizes
+# 14, 16, 20x10, 24x12, 28x14 and 32x16), TerminusBoldVGA (sizes 14
+# and 16) and Fixed (sizes 13, 14, 15, 16 and 18).  Only when
+# CODESET=Ethiopian: Goha (sizes 12, 14 and 16) and 
+# GohaClassic (sizes 12, 14 and 16).
+# Set FONTFACE and FONTSIZE to empty strings if you want setupcon to
+# set up the keyboard but to leave the console font unchanged.
+FONTFACE="Terminus"
+FONTSIZE="16"
+
+# You can also directly specify nonstandard font or console map to load.
+# Use space as separator if you want to load more than one font.
+# You can use FONT_MAP in order to specify the Unicode map of the font
+# in case the font doesn't have it embedded.
+
+# FONT='lat9w-08.psf.gz /usr/local/share/braillefonts/brl-08.psf'
+# FONT_MAP=/usr/share/consoletrans/lat9u.uni
+# CONSOLE_MAP=/usr/local/share/consoletrans/my_special_encoding.acm
+
+# You can also specify a screen size that setupcon will enforce.  This can not
+# exceed what the current screen resolution can display according to the size of
+# the loaded font.
+#
+# SCREEN_WIDTH=80
+# SCREEN_HEIGHT=25
+
+if [ -f /etc/default/keyboard ]; then
+    . /etc/default/keyboard
+fi

--- a/profiles/SCI-amd64.files/files/default/keyboard
+++ b/profiles/SCI-amd64.files/files/default/keyboard
@@ -1,0 +1,16 @@
+# Check /usr/share/doc/keyboard-configuration/README.Debian for
+# documentation on what to do after having modified this file.
+
+# The following variables describe your keyboard and can have the same
+# values as the XkbModel, XkbLayout, XkbVariant and XkbOptions options
+# in /etc/X11/xorg.conf.
+
+XKBMODEL="pc105"
+XKBLAYOUT="us,ru"
+XKBVARIANT=","
+XKBOPTIONS="grp:alt_shift_toggle,grp_led:scroll"
+
+# If you don't want to use the XKB layout on the console, you can
+# specify an alternative keymap.  Make sure it will be accessible
+# before /usr is mounted.
+# KMAP=/etc/console-setup/defkeymap.kmap.gz

--- a/profiles/SCI-amd64.files/postinst.sh
+++ b/profiles/SCI-amd64.files/postinst.sh
@@ -192,6 +192,10 @@ echo Setting up defaults
 
 ./strreplace.sh $target/etc/default/xendomains "^XENDOMAINS_SAVE" 'XENDOMAINS_SAVE=""'
 
+## Set localized console and keyboard
+
+cp files/default/* $target/etc/default/
+
 ## Add startup script rc.sci to setup performance
 
 # a bit ugly, but fast ;)

--- a/profiles/SCI-amd64.packages
+++ b/profiles/SCI-amd64.packages
@@ -35,3 +35,4 @@ acpi-support-base
 ipcalc
 mc
 usbmount
+console-setup


### PR DESCRIPTION
There is the problem with preseeding because console-setup
is configured another way in the installes.

So it is done via /etc/default/\* files
