### PR TITLE
ntp and ntpdate move from downloads to packages

### DIFF
--- a/profiles/SCI-amd64.downloads
+++ b/profiles/SCI-amd64.downloads
@@ -12,9 +12,6 @@ less
 
 iproute
 
-ntp
-ntpdate
-
 bind9
 dnsutils
 

--- a/profiles/SCI-amd64.packages
+++ b/profiles/SCI-amd64.packages
@@ -36,3 +36,5 @@ ipcalc
 mc
 usbmount
 console-setup
+ntpdate
+ntp


### PR DESCRIPTION
Because the time function is for nodes and sugested
